### PR TITLE
Clean up CRDs on tf destroy

### DIFF
--- a/crds.tf
+++ b/crds.tf
@@ -14,6 +14,6 @@ resource "null_resource" "crds" {
 
   provisioner "local-exec" {
     when = "destroy"
-    command = "kubectl delete --all crd -n ${local.linkerd_namespace}"
+    command = "kubectl delete -f - <<EOF\n${data.template_file.crds.rendered}\nEOF"
   }
 }


### PR DESCRIPTION
#6 

Simple fix to delete CRDs on tf destroy by adding a when flag a deletion local_exec provisioner